### PR TITLE
Change return type to SegmentBuidler.

### DIFF
--- a/src/main/java/com/alexfu/sqlitequerybuilder/builder/SelectLimitBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/builder/SelectLimitBuilder.java
@@ -14,7 +14,7 @@ public class SelectLimitBuilder extends SegmentBuilder {
     this.limit = limit;
   }
 
-  public SelectLimitBuilder offset(int offset) {
+  public SegmentBuilder offset(int offset) {
     this.offset = offset;
     return this;
   }


### PR DESCRIPTION
This forces calling 'build()' after using 'offset' instead of allowing another 'offset' expression which is invalid SQL syntax.