### PR TITLE
Guide user to the correct method call in DROP statement

### DIFF
--- a/src/main/java/com/alexfu/sqlitequerybuilder/builder/DropSegmentBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/builder/DropSegmentBuilder.java
@@ -36,7 +36,7 @@ public class DropSegmentBuilder extends SegmentBuilder {
     return new DropSegmentBuilder(DropType.TRIGGER, trigger);
   }
 
-  public DropSegmentBuilder ifExists() {
+  public SegmentBuilder ifExists() {
     ifExists = true;
     return this;
   }


### PR DESCRIPTION
@alexfu, please review the request. Thanks to @monxalo for the idea.
In relation to #20, this will guide user to the correct method in DROP statement. 

Users could select the wrong method when building a DROP statement.
- Change the return type of `ifExists()` to `SegmentBuilder`.