### PR TITLE
Better memory efficient StringUtils join.

### DIFF
--- a/src/main/java/com/alexfu/sqlitequerybuilder/utils/StringUtils.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/utils/StringUtils.java
@@ -7,14 +7,12 @@ public class StringUtils {
 
   public static String join(CharSequence delimiter, Object... array) {
     StringBuilder sb = new StringBuilder();
-    boolean firstTime = true;
-    for (Object object : array) {
-      if (firstTime) {
-        firstTime = false;
-      } else {
+
+    for (int i = 0, size = array.length; i < size; i++) {
+      if (i > 0) {
         sb.append(delimiter);
       }
-      sb.append(object);
+      sb.append(array[i]);
     }
     return sb.toString();
   }

--- a/src/main/java/com/alexfu/sqlitequerybuilder/utils/StringUtils.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/utils/StringUtils.java
@@ -1,19 +1,21 @@
 package com.alexfu.sqlitequerybuilder.utils;
 
 public class StringUtils {
-  public static String join(String delimeter, String... array) {
-    return join(delimeter, (Object[]) array);
+  public static String join(CharSequence delimiter, String... array) {
+    return join(delimiter, (Object[]) array);
   }
 
-  public static String join(String delimeter, Object... array) {
-    String result = "";
-    for (int i = 0, size = array.length; i < size; i++) {
-      result += array[i].toString();
-      if (i < size - 1) {
-        result += delimeter;
+  public static String join(CharSequence delimiter, Object... array) {
+    StringBuilder sb = new StringBuilder();
+    boolean firstTime = true;
+    for (Object object : array) {
+      if (firstTime) {
+        firstTime = false;
+      } else {
+        sb.append(delimiter);
       }
+      sb.append(object);
     }
-
-    return result;
+    return sb.toString();
   }
 }


### PR DESCRIPTION
Use a StringBuilder instead of the operation '+=' since this would
allocate a new StringBuilder in each Loop iteration.

Changed the parameter type from String to CharSequence to allow
other CharSequence objects like StringBuffers.

Also fixed minor typo in 'delimeter'.