### PR TITLE
Support for insert statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: true     # default: false
 after_success:
-- ./gradlew clean checkstyleMain checkstyleTest jacocoTestReport coveralls
+- ./gradlew jacocoTestReport coveralls
 

--- a/src/main/java/com/alexfu/sqlitequerybuilder/api/SQLiteQueryBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/api/SQLiteQueryBuilder.java
@@ -2,8 +2,14 @@ package com.alexfu.sqlitequerybuilder.api;
 
 import com.alexfu.sqlitequerybuilder.builder.*;
 import com.alexfu.sqlitequerybuilder.builder.delete.DeleteBuilder;
+import com.alexfu.sqlitequerybuilder.builder.insert.InsertBuilder;
 
 public class SQLiteQueryBuilder {
+
+  public static InsertBuilder insert() {
+    return new InsertBuilder();
+  }
+
   public static SelectBuilder select(String... fields) {
     return new SelectFieldBuilder(fields);
   }
@@ -15,7 +21,7 @@ public class SQLiteQueryBuilder {
   public static CreateTableSegmentBuilder create() {
     return new CreateTableSegmentBuilder();
   }
-  
+
   public static DropSegmentBuilder drop() {
     return new DropSegmentBuilder();
   }

--- a/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertBuilder.java
@@ -1,0 +1,14 @@
+package com.alexfu.sqlitequerybuilder.builder.insert;
+
+import com.alexfu.sqlitequerybuilder.builder.SegmentBuilder;
+
+public class InsertBuilder extends SegmentBuilder {
+  public InsertIntoBuilder into(String table) {
+    return new InsertIntoBuilder(this, table);
+  }
+
+  @Override
+  public String build() {
+    return "INSERT INTO";
+  }
+}

--- a/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertColumnsBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertColumnsBuilder.java
@@ -1,0 +1,23 @@
+package com.alexfu.sqlitequerybuilder.builder.insert;
+
+import com.alexfu.sqlitequerybuilder.builder.SegmentBuilder;
+import com.alexfu.sqlitequerybuilder.utils.StringUtils;
+
+public class InsertColumnsBuilder extends SegmentBuilder {
+  private final SegmentBuilder predicate;
+  private final String[] columns;
+
+  public InsertColumnsBuilder(SegmentBuilder predicate, String[] columns) {
+    this.predicate = predicate;
+    this.columns = columns;
+  }
+
+  public InsertValuesBuilder values(Object...values) {
+    return new InsertValuesBuilder(this, values);
+  }
+
+  @Override
+  public String build() {
+    return predicate.build() + " (" + StringUtils.join(",", columns) + ")";
+  }
+}

--- a/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertIntoBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertIntoBuilder.java
@@ -1,0 +1,23 @@
+package com.alexfu.sqlitequerybuilder.builder.insert;
+
+import com.alexfu.sqlitequerybuilder.builder.SegmentBuilder;
+import com.alexfu.sqlitequerybuilder.utils.StringUtils;
+
+public class InsertIntoBuilder extends SegmentBuilder {
+  private final InsertBuilder predicate;
+  private final String table;
+
+  public InsertIntoBuilder(InsertBuilder predicate, String table) {
+    this.predicate = predicate;
+    this.table = table;
+  }
+
+  public InsertColumnsBuilder columns(String...columns) {
+    return new InsertColumnsBuilder(this, columns);
+  }
+
+  @Override
+  public String build() {
+    return StringUtils.join(" ", predicate.build(), table);
+  }
+}

--- a/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertValuesBuilder.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/builder/insert/InsertValuesBuilder.java
@@ -1,0 +1,41 @@
+package com.alexfu.sqlitequerybuilder.builder.insert;
+
+import com.alexfu.sqlitequerybuilder.builder.SegmentBuilder;
+import com.alexfu.sqlitequerybuilder.utils.DateUtils;
+import com.alexfu.sqlitequerybuilder.utils.StringUtils;
+
+import java.util.Calendar;
+
+public class InsertValuesBuilder extends SegmentBuilder {
+  private final SegmentBuilder predicate;
+  private final Object[] values;
+
+  public InsertValuesBuilder(SegmentBuilder predicate, Object[] values) {
+    this.predicate = predicate;
+    this.values = clean(values);
+  }
+
+  private Object[] clean(Object[] values) {
+    Object[] clean = new Object[values.length];
+    for (int i = 0; i < values.length; i++) {
+      Object item = values[i];
+
+      if (item instanceof String) {
+        item = "'" + item + "'";
+      }
+
+      if (item instanceof Calendar) {
+        Calendar date = (Calendar) item;
+        item = "'" + DateUtils.iso8601().format(date.getTime()) + "'";
+      }
+
+      clean[i] = item;
+    }
+    return clean;
+  }
+
+  @Override
+  public String build() {
+    return predicate.build() + " values (" + StringUtils.join(",", values) + ")";
+  }
+}

--- a/src/main/java/com/alexfu/sqlitequerybuilder/utils/DateUtils.java
+++ b/src/main/java/com/alexfu/sqlitequerybuilder/utils/DateUtils.java
@@ -1,0 +1,15 @@
+package com.alexfu.sqlitequerybuilder.utils;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+public class DateUtils {
+  private static DateFormat ISO8601;
+
+  public static DateFormat iso8601() {
+    if (ISO8601 == null) {
+      ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ");
+    }
+    return ISO8601;
+  }
+}

--- a/src/test/java/com/alexfu/sqlitequerybuilder/InsertTest.java
+++ b/src/test/java/com/alexfu/sqlitequerybuilder/InsertTest.java
@@ -13,11 +13,13 @@ public class InsertTest {
   public void simple() {
     Calendar timestamp = Calendar.getInstance();
     String sql = SQLiteQueryBuilder.insert()
-        .into("people")
-        .columns("id", "name", "timestamp")
-        .values(1, "John", Calendar.getInstance())
-        .build();
+      .into("people")
+      .columns("id", "name", "timestamp")
+      .values(1, "John", Calendar.getInstance())
+      .build();
 
-    assertThat(sql).isEqualTo("INSERT INTO people (id,name,timestamp) values (1,'John','" + DateUtils.iso8601().format(timestamp.getTime()) + "')");
+    String iso8601 = DateUtils.iso8601().format(timestamp.getTime());
+    String result = "INSERT INTO people (id,name,timestamp) values (1,'John','" + iso8601 + "')";
+    assertThat(sql).isEqualTo(result);
   }
 }

--- a/src/test/java/com/alexfu/sqlitequerybuilder/InsertTest.java
+++ b/src/test/java/com/alexfu/sqlitequerybuilder/InsertTest.java
@@ -1,0 +1,23 @@
+package com.alexfu.sqlitequerybuilder;
+
+import com.alexfu.sqlitequerybuilder.api.SQLiteQueryBuilder;
+import com.alexfu.sqlitequerybuilder.utils.DateUtils;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InsertTest {
+  @Test
+  public void simple() {
+    Calendar timestamp = Calendar.getInstance();
+    String sql = SQLiteQueryBuilder.insert()
+        .into("people")
+        .columns("id", "name", "timestamp")
+        .values(1, "John", Calendar.getInstance())
+        .build();
+
+    assertThat(sql).isEqualTo("INSERT INTO people (id,name,timestamp) values (1,'John','" + DateUtils.iso8601().format(timestamp.getTime()) + "')");
+  }
+}


### PR DESCRIPTION
Adds basic support for insert statements. Usage:

```
String sql = SQLiteQueryBuilder.insert()
  .into("people")
  .columns("id", "name", "timestamp")
  .values(1, "John", Calendar.getInstance())
  .build();
```

which will result in...

```
INSERT INTO people (id,name,timestamp) values (1,'John','2016-01-15T07:22-0500')
```